### PR TITLE
MVP USER TESTING: Search - Gray out stocks already in watchlist

### DIFF
--- a/frontend/app/dashboard/components/sidebar/searchbar.tsx
+++ b/frontend/app/dashboard/components/sidebar/searchbar.tsx
@@ -85,7 +85,17 @@ export function SearchBar() {
           ) : (
             <CommandGroup heading="Securities">
               {assets.slice(0, 100).map((asset) => (
-                <CommandItem key={asset.ticker} className="p-2">
+                <CommandItem
+                  key={asset.ticker}
+                  className="p-2 mb-2"
+                  style={{
+                    background: watchlist.some(
+                      (item) => item.Ticker === asset.ticker
+                    )
+                      ? "repeating-linear-gradient(45deg, #f3f4f6, #f3f4f6 10px, #e5e7eb 10px, #e5e7eb 20px)"
+                      : "",
+                  }}
+                >
                   <div
                     className="grid grid-cols-6 gap-4 items-center"
                     onClick={() => {

--- a/frontend/zustand/store.ts
+++ b/frontend/zustand/store.ts
@@ -111,6 +111,12 @@ export const useStore = create<Store>((set, get) => ({
       const data = await response.json();
       const tickers = data.Tickers || [];
 
+      tickers.sort((stock1: WatchlistItem, stock2: WatchlistItem) => {
+        if (stock1.Ticker < stock2.Ticker) return -1;
+        if (stock1.Ticker > stock2.Ticker) return 1;
+        return 0;
+      });
+
       set({ watchlist: tickers });
 
       // if no asset currently selected --> select 1st asset in the watchlist


### PR DESCRIPTION
# PR#39 <!-- ex: PR#100-->

Resolves #33 

## **NOTE** All of the recent PRs made by @dani-ribeiro (from mvp user testing) merge into one another (otherwise they would all have the same changes). It's important that you accept merges, when ready, in the order from top (most recent) to bottom (oldest)


## Type of Changes

<!-- Put an x in the checkboxs that apply. ex: - [x] Bug fix -->

- [ ] Bug fix
- [x] New feature

## Description

<!-- Describe your changes here -->
<!-- What does this PR do/fix? -->

- When a user has already added a stock to their watchlist, that same stock will now appear grayed out (or with a striped background) in the search bar. If the user still decides to click on that stock, they will get a notification directly telling them that the stock is already in their watchlist.
- Additionally, I noticed the watchlist tickers were listed in the order they were added, which isn't really helpful. So I sorted the tickers in alphabetical order.


## How has this been tested?

<!-- List reproduction steps -->
<!-- ex:
    1. Navigate to login page
    2. Enter credentials
        2a. Valid Credentials -> information authenticated and user redirected to dashboard
        2b. Invalid Credentials -> error message displayed and user is NOT redirected
    ...
-->

1. Add a stock to your watchlist
2. Notice that the stock is now grayed out in the search menu
3. Add/remove multiple stocks
4. Notice that the stocks are listed in alphabetical order in the watchlist

## Screenshots (if necessary)
![Kapture 2025-02-28 at 17 02 35](https://github.com/user-attachments/assets/2801fae8-2a5c-4843-9c90-04da53547eee)