### PR TITLE
BETA USER TESTING: Dashboard Overview - Learn More opens in new tab

### DIFF
--- a/backend/assets/asset_collection.py
+++ b/backend/assets/asset_collection.py
@@ -10,7 +10,7 @@ current_directory = os.path.join(os.getcwd(), 'assets')
 assets_json_path = os.path.join(current_directory, 'assets.json')
 
 def upload_mongo():
-    client = MongoClient(os.getenv("MONGO_URL"))
+    client = MongoClient(os.getenv("MONGO_URI"))
     db = client["stock_dashboard"]
     collection = db["assets"]
 

--- a/frontend/app/dashboard/components/asset-info/asset-info.tsx
+++ b/frontend/app/dashboard/components/asset-info/asset-info.tsx
@@ -104,13 +104,13 @@ export function AssetInfo() {
                   <CollapsibleTrigger asChild>
                     <Button variant="ghost" size="sm" className="p-2">
                       <ChevronsUpDown className="h-4 w-4" />
-                      <span>{descriptionOpen ? "Show less" : "Show more"}</span>
+                      <span>{descriptionOpen ? "Show Less" : "Show More"}</span>
                     </Button>
                   </CollapsibleTrigger>
                 )}
               </div>
             </Collapsible>
-            <Link href={descriptionData.website} passHref>
+            <Link href={descriptionData.website} passHref target="_blank">
               <Button className="mt-4 bg-button-foreground hover:bg-button-background text-accent text-xs px-3 py-2 rounded-lg">
                 Learn More
               </Button>


### PR DESCRIPTION
# PR#49 <!-- ex: PR#100-->

Resolves #48 

## Type of Changes

<!-- Put an x in the checkboxs that apply. ex: - [x] Bug fix -->

- [x] Bug fix
- [ ] New feature

## Description

<!-- Describe your changes here -->
<!-- What does this PR do/fix? -->

Changes `Learn More` button behavior to open a company's home page in a new tab, rather than redirecting the current tab. 
Additionally capitalizes `Learn More`, `Show More`, `Show Less`

This fix was requested during user testing because otherwise users would lose their positioning in the app, and have to re-search for the asset after clicking `Learn More`

## How has this been tested?

<!-- List reproduction steps -->
<!-- ex:
    1. Navigate to login page
    2. Enter credentials
        2a. Valid Credentials -> information authenticated and user redirected to dashboard
        2b. Invalid Credentials -> error message displayed and user is NOT redirected
    ...
-->

- Viewed an asset
- Clicked Learn More
- Company's home page opened in a new tab
