### PR TITLE
BETA USER TESTING: Graphs: Fixes graph scroll view

### DIFF
--- a/frontend/app/dashboard/components/visualizations/timeperiodselector.tsx
+++ b/frontend/app/dashboard/components/visualizations/timeperiodselector.tsx
@@ -1,12 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { useStore } from '../../../../zustand/store';
+import React, { useEffect, useState } from "react";
+import { useStore } from "../../../../zustand/store";
 import { cn, Period, Interval, periodIntervalMap } from "@/lib/utils";
 
 interface TimePeriodSelectorProps {
   hasCandleOption: boolean;
 }
 
-const TimePeriodSelector: React.FC<TimePeriodSelectorProps> = ({ hasCandleOption }) => {
+const TimePeriodSelector: React.FC<TimePeriodSelectorProps> = ({
+  hasCandleOption,
+}) => {
   const selectedPeriod = useStore((state) => state.selectedPeriod as Period);
   const setSelectedPeriod = useStore((state) => state.setSelectedPeriod);
 
@@ -48,7 +50,7 @@ const TimePeriodSelector: React.FC<TimePeriodSelectorProps> = ({ hasCandleOption
                 key={period}
                 onClick={() => handlePeriodChange(period as Period)}
                 className={cn(
-                  "w-24 px-4 py-2 border-c last:border-0 text-center",
+                  "px-4 py-2 border-c last:border-0 text-center",
                   selectedPeriod === period
                     ? "bg-gray-500 rounded text-white"
                     : "bg-transparent text-gray-500 hover:bg-sidebar-hover"
@@ -70,7 +72,7 @@ const TimePeriodSelector: React.FC<TimePeriodSelectorProps> = ({ hasCandleOption
                 key={interval}
                 onClick={() => handleIntervalChange(interval)}
                 className={cn(
-                  "w-24 px-4 py-2 border-c last:border-0 text-center",
+                  "px-4 py-2 border-c last:border-0 text-center",
                   selectedInterval === interval
                     ? "bg-gray-500 rounded text-white"
                     : "bg-transparent text-gray-500 hover:bg-sidebar-hover"
@@ -85,30 +87,30 @@ const TimePeriodSelector: React.FC<TimePeriodSelectorProps> = ({ hasCandleOption
 
       {/* Right side: Chart Type Selector */}
       {hasCandleOption && (
-      <div className="flex space-x-0.5">
-        <button
-          onClick={() => setChartType("area")}
-          className={cn(
-            "w-24 px-4 py-2 border-c last:border-0 text-center",
-            chartType === "area"
-              ? "bg-gray-500 rounded text-white"
-              : "bg-transparent text-gray-500 hover:bg-sidebar-hover"
-          )}
-        >
-          Area
-        </button>
-        <button
-          onClick={() => setChartType("candle")}
-          className={cn(
-            "w-24 px-4 py-2 border-c last:border-0 text-center",
-            chartType === "candle"
-              ? "bg-gray-500 rounded text-white"
-              : "bg-transparent text-gray-500 hover:bg-sidebar-hover"
-          )}
-        >
-          Candle
-        </button>
-      </div>
+        <div className="flex space-x-0.5">
+          <button
+            onClick={() => setChartType("area")}
+            className={cn(
+              "px-4 py-2 border-c last:border-0 text-center",
+              chartType === "area"
+                ? "bg-gray-500 rounded text-white"
+                : "bg-transparent text-gray-500 hover:bg-sidebar-hover"
+            )}
+          >
+            Area
+          </button>
+          <button
+            onClick={() => setChartType("candle")}
+            className={cn(
+              "px-4 py-2 border-c last:border-0 text-center",
+              chartType === "candle"
+                ? "bg-gray-500 rounded text-white"
+                : "bg-transparent text-gray-500 hover:bg-sidebar-hover"
+            )}
+          >
+            Candle
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
# PR#55 <!-- ex: PR#100-->

Resolves #54

## Type of Changes

<!-- Put an x in the checkboxs that apply. ex: - [x] Bug fix -->

- [x] Bug fix
- [ ] New feature

## Description
Changes the graphs and cards to be within view, without need for scrolling. #52 introduced hard-coded widths that forced the user to scroll to see the full graph, which also affected the other cards in the dashboard.

**(Also there were some changes picked up by my linter for spaces/tabs. Don't worry about that, I can't do anything about it when I save. The only change in this PR is really removing `w-24` from styling)**

<!-- Describe your changes here -->
<!-- What does this PR do/fix? -->

## How has this been tested?

<!-- List reproduction steps -->
<!-- ex:
    1. Navigate to login page
    2. Enter credentials
        2a. Valid Credentials -> information authenticated and user redirected to dashboard
        2b. Invalid Credentials -> error message displayed and user is NOT redirected
    ...
-->

- Select an asset
- Notice that the user doesn't need to scroll to see everything

## Screenshots (if necessary)

## Before (#52):
<img width="1440" alt="Screenshot 2025-04-01 at 12 06 29 PM" src="https://github.com/user-attachments/assets/00d21572-139d-4c22-a935-533b08e6416a" />

## After (this PR):
<img width="1440" alt="Screenshot 2025-04-01 at 12 05 39 PM" src="https://github.com/user-attachments/assets/b24e22e1-26d1-495b-836f-3ed2010c4bb9" />


## Additional Information (if necessary)
